### PR TITLE
Add launchd template for vrome server

### DIFF
--- a/system/python/README-launchd
+++ b/system/python/README-launchd
@@ -1,0 +1,5 @@
+To automatically run the vrome Python server from launchd on OS X:
+
+- Edit the `path/to/...` strings in `com.github.jinzhu.vrome.plist` to point to the `vrome` executable
+- Copy `com.github.jinzhu.vrome.plist` to `[$HOME]/Library/LaunchAgents`
+- `launchctl load [$HOME]/Library/LaunchAgents/com.github.jinzhu.vrome.plist`

--- a/system/python/com.github.jinzhu.vrome.plist
+++ b/system/python/com.github.jinzhu.vrome.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.github.jinzhu.vrome</string>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProgramArguments</key>
+  <array>
+      <string>path/to/vrome/system/python/vrome</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>WorkingDirectory</key>
+  <string>path/to/vrome/system/python</string>
+</dict>
+</plist>


### PR DESCRIPTION
It currently requires users to manually twiddle paths in the plist file, but is a useful template and includes a readme describing the steps.

A future version should include an install script which automatically manages this configuration (for various platforms), much like the install scheme for defunkt/dotjs.
