### PR TITLE
check whether eventListener was added before

### DIFF
--- a/src/frontend/modules/key-event.js
+++ b/src/frontend/modules/key-event.js
@@ -12,7 +12,11 @@ var KeyEvent = (function() {
       }
     }
 
-    document.addEventListener('keydown',KeyEvent.exec, true);
+    if (! document.vromeEventListenerAdded){
+      Debug("add eventlistener");
+      document.addEventListener('keydown',KeyEvent.exec, true);
+    }
+    document.vromeEventListenerAdded = true;
   }
 
   function getTimes(/*Boolean*/ read) {


### PR DESCRIPTION
Hi,
First of all, thank you for creating vrome. I really love it.
In my environments (Google Chrome 13.0.782.112 m on Windows and Chromium 12.0.742.112 (90304) on Ubuntu 11.04), "keydown" event listner is added twice sometimes, and single key stroke invokes vrome command twice. For example, typing <C-d> resulted in scrolling up full page. This happened on some pages (ex. search result of Google), but did not on others.

This patch, just checking whether an event listener was added before, seems to solve the problem, though I'm not sure this is the right way (I'm not familiar with JavaScript and development of Chrome Extension).

Anyway, thanks again for your nice Chrome extension.

regards,

Yuto HAYAMIZU
