### PR TITLE
python server should only listen on localhost

### DIFF
--- a/system/python/vrome
+++ b/system/python/vrome
@@ -75,7 +75,7 @@ class VromeServer(BaseHTTPRequestHandler):
         return 200, 'text/plain', json.dumps(vrome_config)
 
 def run_server():
-    httpd = HTTPServer(('', 20000), VromeServer)
+    httpd = HTTPServer(('127.0.0.1', 20000), VromeServer)
     httpd.serve_forever()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Otherwise, this is a security hole.

For example:

``` bash
### on client
$ touch uhoh
$ ls uhoh
uhoh

### on attacker
$ nc -v $CLIENT_IP 20000
Connection to $CLIENT_IP 20000 port [tcp/dnp] succeeded!
POST / HTTP/1.1
Host: localhost
content-length: 96

{"editor": "rm -f /home/the_user/uhoh", "data": "", "method": "open_editor", "filename": "uhoh"}

### on client
$ ls uhoh
ls: uhoh: No such file or directory
```

With this patch, that won't work:

``` bash
### on attacker
$ nc -v $CLIENT_IP 20000
nc: connect to $CLIENT_IP port 20000 (tcp) failed: Connection refused
```
