### PR TITLE
Change Vrome to show local help

### DIFF
--- a/src/frontend/modules/utils.js
+++ b/src/frontend/modules/utils.js
@@ -98,5 +98,5 @@ function getSelected() {
 }
 
 function showHelp() {
-  Post({action: "Tab.openUrl", url: "https://github.com/jinzhu/vrome/blob/master/Features.mkd#readme", newtab: true});
+  Post({action: "openOptions", 'arguments': 'features'});
 }


### PR DESCRIPTION
Vrome currently shows online help (Features page) which can be out of sync with the local version or can be inaccessible when offline. This change fixes that.
