### PR TITLE
Speed up the display of link hints.

### DIFF
--- a/src/frontend/modules/hint.js
+++ b/src/frontend/modules/hint.js
@@ -18,7 +18,7 @@ var Hint = (function() {
 
     // Get all visible elements
     var elems = document.body.querySelectorAll('a, input:not([type=hidden]), textarea, select, button, *[onclick]');
-    for (var i=0; i < elems.length; i++) {
+    for (var i = 0, j = elems.length; i < j; i++) {
       if (isElementVisible(elems[i])) { elements.push(elems[i]); }
     }
     setHintIndex(elements);
@@ -26,7 +26,7 @@ var Hint = (function() {
   }
 
   function removeHighlightBox(/* Boolean */ create_after_remove) {
-    for (var i = 0; i < elements.length; i++) { elements[i].removeAttribute(highlight); }
+    for (var i = 0, j = elements.length; i < j; i++) { elements[i].removeAttribute(highlight); }
 
     var div = document.getElementById('__vim_hint_highlight');
     if (div) { document.body.removeChild(div); }
@@ -44,7 +44,7 @@ var Hint = (function() {
     var win_top   = window.scrollY / Zoom.current();
     var win_left  = window.scrollX / Zoom.current();
     var frag = document.createDocumentFragment();
-    for (var i = 0; i < elems.length; i++) { //TODO need refactor
+    for (var i = 0, j = elems.length; i < j; i++) { //TODO need refactor
       var elem      = elems[i];
       var pos       = elem.getBoundingClientRect();
       var elem_top  = win_top  + pos.top;
@@ -158,7 +158,7 @@ var Hint = (function() {
     selected = 0;
     matched  = [];
 
-    for (var i=0; i < elements.length; i++) {
+    for (var i = 0, j = elements.length; i < j; i++) {
       if (hintMatch(elements[i], i)) {
         matched.push(elements[i]);
       }
@@ -167,7 +167,7 @@ var Hint = (function() {
     setHintIndex(matched);
 
     if (isCtrlAcceptKey(key)) {
-      for (var i=0; i < matched.length; i++) {
+      for (var i = 0, j = matched.length; i < j; i++) {
         execSelect(matched[i]);
         new_tab = true;
       }


### PR DESCRIPTION
Currently, on my aging netbook, hitting `f` while on [reddit](http://reddit.com) takes between 1500-2500 ms to paint the links yellow.

Initially, I expected the constant calls to `isElementVisible` to be where most of the work was spent. It turns out that it's not the calculations that are slow, it's the constant painting & reflowing that goes on when lots of links are present. To solve this, in 7a6121a1 I've introduced a document fragment ([basically a screen buffer](http://code.google.com/speed/articles/javascript-dom.html)) which has all the `<spans>` appended into it in the loop, and then, once the loop is finished (and all links are hinted), the fragment is appended back into the main `<div>`, triggering just one paint/reflow action.

This, alone, reduced my average timing from 2400~ms to 200~ms, which is surprisingly substantial.

At the same time, I've moved the calculation for the `win_top` and `win_left` offsets out of the loop, so they're only set once, because they shouldn't be changing arbitrarily in the middle of that loop, I don't think. That's commit f40e6547

Finally, in 8b502c96, a minor tweak that shouldn't hurt: All the for loops involved in hinting have their iterator lengths pre-calculated, rather than on each iteration. 
