### PR TITLE
Add return statements after loops

### DIFF
--- a/coffee/background/scripts/modules/buffer.coffee
+++ b/coffee/background/scripts/modules/buffer.coffee
@@ -17,6 +17,7 @@ class Buffer
 
     chrome.tabs.getAllInWindow tab.windowId, (tabs) ->
       Tab.close(tab) for tab in getMatchedTabs(tabs, keyword)
+      return
 
   @deleteNotMatch: (msg) ->
     [tab, keyword] = [getTab(arguments), msg.keyword]
@@ -24,6 +25,7 @@ class Buffer
     chrome.tabs.getAllInWindow tab.windowId, (tabs) ->
       matched_tabs = getMatchedTabs(tabs, keyword)
       Tab.close(tab) for tab in tabs when tab not in matched_tabs
+      return
 
 root = exports ? window
 root.Buffer = Buffer

--- a/coffee/background/scripts/modules/command.coffee
+++ b/coffee/background/scripts/modules/command.coffee
@@ -15,6 +15,7 @@ class Command
           "var script = document.createElement('link'); script.setAttribute('href', '#{src}'); script.setAttribute('rel', 'stylesheet'); document.body.appendChild(script);"
         chrome.tabs.executeScript(tab.id, code: data)
         # $.ajax type: 'GET', url: src, dataType : 'text', success: (data) -> injectCode(data, src, tab)
+    return
 
 
 root = exports ? window

--- a/coffee/background/scripts/modules/tab.coffee
+++ b/coffee/background/scripts/modules/tab.coffee
@@ -34,8 +34,9 @@ class Tab
 
     [first_url, index] = [urls.shift(), tab.index]
 
-    openUrls = (window) =>
+    openUrls = (window) ->
       chrome.tabs.create(windowId: window.id, url: url, index: ++index, selected: false) for url in urls
+      return
 
     if msg.incognito
       chrome.windows.create {incognito: true, url: first_url}, openUrls
@@ -104,6 +105,7 @@ class Tab
               (not cond and (t.index >= index) and (t.index < (index + Math.max(1, count))))
             )
               remove t
+      return
 
 
   @select: (msg) ->
@@ -133,6 +135,7 @@ class Tab
       chrome.tabs.getAllInWindow tab.windowId, (tabs) ->
         # Reverse reload all tabs to avoid issues in development mode
         chrome.tabs.reload t.id for t in tabs.reverse()
+        return
     else
       chrome.tabs.reload tab.id, {bypassCache: !!msg.bypassCache}
 
@@ -148,12 +151,14 @@ class Tab
       for w in windows
         for t in w.tabs when t.pinned && (msg.allWindows || (w.id is tab.windowId))
           @update {pinned: false}, t
+      return
 
 
   @duplicate: (msg) ->
     tab = getTab(arguments)
     [index, count] = [tab.index, msg.count ? 1]
     chrome.tabs.create {url: tab.url, index: ++index, selected: false} while count-- > 0
+    return
 
 
   @detach: ->

--- a/coffee/background/scripts/modules/window.coffee
+++ b/coffee/background/scripts/modules/window.coffee
@@ -9,6 +9,7 @@ class Window
   @closeAll: () ->
     chrome.windows.getAll (windows) ->
       chrome.windows.remove(window.id) for window in windows
+      return
 
   @capture: () ->
     tab = getTab(arguments)

--- a/coffee/frontend/modules/autolink.coffee
+++ b/coffee/frontend/modules/autolink.coffee
@@ -2,8 +2,7 @@ class AutoLink
 
   url_regexp = /(((https?|ftp|file):\/\/)?([\w]{2,}\.)+[\w]{2,5}(\/[\S]+)*)/g
   textNodes = (elems)->
-    for e in elems when e.data?.match(url_regexp) and (e.nodeType == 3) and (e.nodeName not in ["INPUT", "TEXTAREA"])
-      e
+    e for e in elems when e.data?.match(url_regexp) and (e.nodeType == 3) and (e.nodeName not in ["INPUT", "TEXTAREA"])
 
 
   @makeLink: (elems=null) ->
@@ -13,6 +12,7 @@ class AutoLink
         value = jQuery(elem).text().replace url_regexp, ($0, $1) ->
           "<a href='#{if /^(\w+\.)+\w+/.test($1) then "http://#{$1}" else $1}'>#{$1}</a>"
         jQuery(elem).after(value).remove()
+    return
   desc @makeLink, "Transforms URLs into clickable links"
 
 

--- a/coffee/frontend/modules/dialog.coffee
+++ b/coffee/frontend/modules/dialog.coffee
@@ -31,6 +31,7 @@ class Dialog
 
     for index in [max_num..0]
       $(".#{quick_num}:contains(#{index})").get(0)?.scrollIntoViewIfNeeded()
+    return
 
 
   notice = (msg) ->

--- a/coffee/frontend/modules/hint.coffee
+++ b/coffee/frontend/modules/hint.coffee
@@ -30,6 +30,7 @@ class Hint
       $(highlight_box).append span
       offset = $(elem).offset()
       span.offset left: offset.left-6, top: offset.top
+    return
 
   setMatched = (elems) =>
     @matched = elems

--- a/coffee/frontend/modules/page.coffee
+++ b/coffee/frontend/modules/page.coffee
@@ -6,6 +6,7 @@ class Page
     for regexp in regexps
       for [elem, value] in elems
         return clickElement(elem) if new RegExp(regexp, "i").test(value)
+    return
 
   @copySelected: ->
     text = getSelected()

--- a/coffee/frontend/modules/url.coffee
+++ b/coffee/frontend/modules/url.coffee
@@ -65,7 +65,7 @@ class Url
         pathname = pathname.replace(/\/[^\/]*\/?$/, '') + path
       else if path.match(/^.\//)
         pathname = pathname.replace(/\/$/, '') + path.replace(/^.\//, '/')
-    return pathname
+    pathname
 
 
   fixUrl = (url_str) =>
@@ -100,7 +100,7 @@ class Url
         url = encodeURIComponent(url)
         result.push Option.default_search_url(url)
 
-    return result
+    result
 
 
   @parent: ->

--- a/coffee/frontend/modules/utils.coffee
+++ b/coffee/frontend/modules/utils.coffee
@@ -77,5 +77,6 @@ root.runIt = (func, args) ->
         f[0].call "", f[1]
       else
         Debug "RunIt(Not Run): function #{f}"
+    return
   else
     setTimeout runIt, 10


### PR DESCRIPTION
Add `return` statements after loops as the CoffeeScript compiler will aggregate the last line in them and return that as the result of the function. We can speed up things by making it not do that.

Please make sure that I haven't accidentally put a `return` where there shouldn't be one - that is, where actually the side-effect of returning the accumulated values is used (e.g. in `frontend/modules/autolink.coffee` in the `textNodes` function).
