### PR TITLE
Faster startup (because of faster event handler addition)

### DIFF
--- a/coffee/frontend/main.coffee
+++ b/coffee/frontend/main.coffee
@@ -3,13 +3,13 @@ root = exports ? window
 root.Post = (msg) ->
   chrome.runtime.sendMessage msg, (response) ->
 
-addErrorLogger = ->
-  window.addEventListener "error", ((err) ->
-    Debug err
-  ), false
+window.addEventListener "error", ((err) -> Debug err), false
 
 try
-  runIt Settings.init, -> func.call() for func in [Zoom.init, KeyEvent.init, Custom.runJS, Custom.loadCSS]
-  runIt addErrorLogger
+  Settings.init ->
+    do KeyEvent.init
+    $ ->
+      func.call() for func in [Zoom.init, Custom.runJS, Custom.loadCSS]
+      return
 catch err
   Debug err

--- a/coffee/frontend/modules/utils.coffee
+++ b/coffee/frontend/modules/utils.coffee
@@ -60,23 +60,3 @@ root.clickElement = (elem, opt={}) ->
   #   Post action: "Tab.openUrl", url: $(elem).attr("href"), newtab: false
 
   elem.setAttribute "target", old_target  if old_target
-
-
-initFunctions = []
-root.runIt = (func, args) ->
-  if $.isArray func
-    initFunctions = initFunctions.concat(func)
-  else if $.isFunction(func)
-    initFunctions.push [func, args]
-
-  if document.body
-    while f = initFunctions.shift()
-      if $.isFunction(f)
-        f.call()
-      else if $.isFunction f[0]
-        f[0].call "", f[1]
-      else
-        Debug "RunIt(Not Run): function #{f}"
-    return
-  else
-    setTimeout runIt, 10

--- a/coffee/frontend/modules/zoom.coffee
+++ b/coffee/frontend/modules/zoom.coffee
@@ -8,11 +8,11 @@ class Zoom
 
   setZoom = (count, keepCurrentPage) ->
     index = (if count then (currentLevel() + times() * count) else default_index)
-    
+
     # index should >= 0 && < levels.length
     index = Math.min(levels.length - 1, Math.max(0, index))
     level = index - default_index
-    
+
     # 0 is default value. no need to set it for every site
     Settings.add zoom_level: (index - default_index), scope_key: "host"
     topPercent = scrollY / document.height

--- a/coffee/shared/settings.coffee
+++ b/coffee/shared/settings.coffee
@@ -26,7 +26,8 @@ class Settings
 
   syncLocal = (callback) =>
     local_key = get_key(arguments)
-    local.get local_key, (obj) => settings[local_key] = obj[local_key] if local_key isnt "background"
+    if local_key isnt "background"
+      local.get local_key, (obj) => settings[local_key] = obj[local_key]
     local.get "background", (obj) =>
       try
         settings["background"] = obj['background'] || JSON.parse(localStorage['__vrome_setting'] || "{}")


### PR DESCRIPTION
KeyEvent.init should be the first thing to be called (after the settings are read) in order to have a responsive UI. I'm trying to figure out if this cold go even faster, as I really hate it when a new tab is opened that I cannot, e.g., change tabs because the keypress event handler hasn't been added yet...
