### PR TITLE
Search upgrades

### DIFF
--- a/coffee/frontend/modules/search.coffee
+++ b/coffee/frontend/modules/search.coffee
@@ -74,6 +74,8 @@ class Search
 
   @onAcceptKeyPressed: =>
     return unless searchMode
+    return @stop() if nodes.length is 0
+
     if CmdBox.isActive()
       InsertMode.blurFocus()
     else


### PR DESCRIPTION
Do not search if no letters entered. Set title to 'Nothing found' if nothing is found. Exit search mode on Enter if nothing is found.
