### PR TITLE
Disable getpocket.com and instapaper.com in the vromerc_example

### DIFF
--- a/src/vromerc_example
+++ b/src/vromerc_example
@@ -47,7 +47,7 @@ set noautocomplete
 set disable_autofocus
 
 " Disable Vrome in those sites, Multiple URLs can be separated with ,
-set disablesites=mail.google.com, reader.google.com
+set disablesites=mail.google.com, reader.google.com, getpocket.com, instapaper.com
 
 " Set your hintkeys instead of the default 0123456789
 set hintkeys=jlkhfsdagwerui


### PR DESCRIPTION
These common reader sites do not work well with vim commands and have their own nice set of shortcuts. Default behavior should probably be to ignore them.